### PR TITLE
pip install wheel avant d'installer Grammalecte

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ python padpo.py a_directory_containing_po_files
    ```
 4. Get grammalecte
    ```bash
+   pip install wheel
    wget https://grammalecte.net/grammalecte/zip/Grammalecte-fr-v1.5.0.zip
    unzip  Grammalecte-fr-v1.5.0.zip -d Grammalecte-fr-v1.5.0
    cd Grammalecte-fr-v1.5.0


### PR DESCRIPTION
Je viens de regarder ton script. Ça a l'air très puissant, je l'ai fait passer sur quelques fichiers et il est bon à trouver des bêtises. J'ai enlevé les avertissements sur les espaces insécables et doubles, il y a des balises poedit pas encore échappées mais il y a du potentiel. Le sel faux positif que j'ai vu est de corriger certains verbes à l'infinitif que Grammalecte considère à l'impératif (je n'ai pas regardé toutes les règles mais il doit y avoir moyen de supprimer ça).
Je ferai une PR ce soir sur un fichier avec les erreurs que j'ai trouvées pour montrer aux autres. 

Sinon une PR avant que j'oublie pour installer wheel nécessaire au setup de Grammalecte Python.